### PR TITLE
Update _models_py3.py

### DIFF
--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models_py3.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_generated/models/_models_py3.py
@@ -6385,7 +6385,7 @@ class PatternAnalyzer(LexicalAnalyzer):
         *,
         name: str,
         lower_case_terms: bool = True,
-        pattern: str = "\W+",
+        pattern: str = r"\W+",
         flags: Optional[Union[str, "_models.RegexFlags"]] = None,
         stopwords: Optional[List[str]] = None,
         **kwargs: Any
@@ -6610,7 +6610,7 @@ class PatternTokenizer(LexicalTokenizer):
         self,
         *,
         name: str,
-        pattern: str = "\W+",
+        pattern: str = r"\W+",
         flags: Optional[Union[str, "_models.RegexFlags"]] = None,
         group: int = -1,
         **kwargs: Any


### PR DESCRIPTION
# Description
Pytest tests fail when importing the `azure-search-documents==11.5.1` library due to syntax error when using python 3.12.

## Related documentation about the issue

As documented in this [python 3.12 change information](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes), SyntaxWarning are now replaced by SyntaxError. 

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)

and also the [python regex doc](https://docs.python.org/3/howto/regex.html#:~:text=In%20addition%2C%20special%20escape%20sequences%20that%20are%20valid%20in%20regular%20expressions%2C%20but%20not%20valid%20as%20Python%20string%20literals%2C%20now%20result%20in%20a%20DeprecationWarning%20and%20will%20eventually%20become%20a%20SyntaxError%2C%20which%20means%20the%20sequences%20will%20be%20invalid%20if%20raw%20string%20notation%20or%20escaping%20the%20backslashes%20isn%E2%80%99t%20used.)

> In addition, special escape sequences that are valid in regular expressions, but not valid as Python string literals, now result in a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning) and will eventually become a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError), which means the sequences will be invalid if raw string notation or escaping the backslashes isn’t used.

To fix the issues, I added the raw string notation before the "\W+" patterns where necessary.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
